### PR TITLE
updateLikes API to use _id instead of slug

### DIFF
--- a/controllers/blogController.js
+++ b/controllers/blogController.js
@@ -69,7 +69,7 @@ const blogDetails = async (req, res) => {
 
 const updateLikes = async (req, res, next) => {
   console.log(req.params);
-  const blog = await Blog.findOne({ slug: req.params.id });
+  const blog = await Blog.findOne({ _id: req.params.id });
   const userId = req.userId;
   if (!blog) {
     return res.status(404).json({ success: false, message: "Blog not found" });


### PR DESCRIPTION
Updated the updateLikes API in blogController.js (line 72) to query the blog using _id instead of slug. This ensures the API works correctly when passing the blog ID in the route, as previously it was expecting slug but the route was using id.
Impact:
1. Fixed inconsistency between route parameter and query.

2. Now the API correctly handles blog likes/unlikes using blog _id.